### PR TITLE
Ot 9

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -1,7 +1,7 @@
 import os
 import json
 import logging
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 from pathlib import Path
 import sys
 from openai import OpenAI
@@ -30,23 +30,22 @@ class Agent:
     Uses PromptBuilder to generate prompts and makes decisions via OpenAI API.
     """
     
-    def __init__(self, 
-                 model_name: str = "gpt-4.1",
-                 temperature: float = 0.7,
+    def __init__(self,
+                 model_name: str = "gpt-5.4",
                  api_key: Optional[str] = None,
-                 system_prompt: Optional[str] = None):
+                 system_prompt: Optional[str] = None,
+                 conversation_id: Optional[str] = None):
         """
         Initialize the Agent.
         
         Args:
             model_name: OpenAI model to use (e.g., 'gpt-4', 'gpt-4o-mini')
-            temperature: Sampling temperature (0.0 to 1.0)
             api_key: OpenAI API key (if None, reads from OPENAI_API_KEY env var)
         """
         self.model_name = model_name
-        self.temperature = temperature
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")
         self.system_prompt = system_prompt
+        self.conversation_id = conversation_id
         
         if not self.api_key:
             raise ValueError(
@@ -58,12 +57,46 @@ class Agent:
         
         logger.info(f"Agent initialized with model: {model_name}")
 
-    def _build_messages(self, user_payload: Dict) -> list:
-        messages = []
+    def _build_input(self, user_payload: Dict) -> list[Dict[str, str]]:
+        return [{"role": "user", "content": json.dumps(user_payload)}]
+
+    def _extract_text(self, response: Any) -> str:
+        text = getattr(response, "output_text", None)
+        if text:
+            return text
+        output = getattr(response, "output", None)
+        if not output:
+            return "{}"
+        chunks: list[str] = []
+        for item in output:
+            content = getattr(item, "content", None) or []
+            for c in content:
+                c_text = getattr(c, "text", None)
+                if c_text:
+                    chunks.append(c_text)
+        return "\n".join(chunks) if chunks else "{}"
+
+    def _run(self, user_payload: Dict) -> Dict:
+        request: Dict[str, Any] = {
+            "model": self.model_name,
+            "input": self._build_input(user_payload),
+        }
         if self.system_prompt:
-            messages.append({"role": "system", "content": self.system_prompt})
-        messages.append({"role": "user", "content": json.dumps(user_payload)})
-        return messages
+            request["instructions"] = self.system_prompt
+        if self.conversation_id:
+            request["conversation"] = self.conversation_id
+
+        response = self.client.responses.create(**request)
+
+        next_conversation_id = (
+            getattr(response, "conversation", None)
+            or getattr(response, "conversation_id", None)
+        )
+        if next_conversation_id:
+            self.conversation_id = next_conversation_id
+
+        content = self._extract_text(response)
+        return self._parse_json_response(content)
 
     def _parse_json_response(self, content: str) -> Dict:
         try:
@@ -85,14 +118,7 @@ class Agent:
             ),
             "game_state": game_state,
         }
-        messages = self._build_messages(payload)
-        response = self.client.chat.completions.create(
-            model=self.model_name,
-            temperature=self.temperature,
-            messages=messages,
-        )
-        content = response.choices[0].message.content or "{}"
-        return self._parse_json_response(content)
+        return self._run(payload)
 
     def make_offer(self, participant_id: int, game_state: Dict) -> Dict:
         payload = {
@@ -105,14 +131,7 @@ class Agent:
             ),
             "game_state": game_state,
         }
-        messages = self._build_messages(payload)
-        response = self.client.chat.completions.create(
-            model=self.model_name,
-            temperature=self.temperature,
-            messages=messages,
-        )
-        content = response.choices[0].message.content or "{}"
-        return self._parse_json_response(content)
+        return self._run(payload)
 
     def respond_to_offer(self, participant_id: int, game_state: Dict) -> Dict:
         payload = {
@@ -124,14 +143,7 @@ class Agent:
             ),
             "game_state": game_state,
         }
-        messages = self._build_messages(payload)
-        response = self.client.chat.completions.create(
-            model=self.model_name,
-            temperature=self.temperature,
-            messages=messages,
-        )
-        content = response.choices[0].message.content or "{}"
-        return self._parse_json_response(content)
+        return self._run(payload)
     
     
     

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -77,6 +77,10 @@ class Agent:
         return "\n".join(chunks) if chunks else "{}"
 
     def _run(self, user_payload: Dict) -> Dict:
+        task = user_payload.get("task", "?")
+        participant_id = user_payload.get("participant_id")
+        conversation_sent = self.conversation_id
+
         request: Dict[str, Any] = {
             "model": self.model_name,
             "input": self._build_input(user_payload),
@@ -88,12 +92,34 @@ class Agent:
 
         response = self.client.responses.create(**request)
 
+        response_id = getattr(response, "id", None)
         next_conversation_id = (
             getattr(response, "conversation", None)
             or getattr(response, "conversation_id", None)
         )
         if next_conversation_id:
             self.conversation_id = next_conversation_id
+
+        # Trace threading: grep logs for "OpenAI conversation trace".
+        # - First call for a participant: conversation_sent=None, conversation_returned should be conv_...
+        # - Later calls: conversation_sent equals that conv_... (same thread for this player).
+        logger.info(
+            "OpenAI conversation trace: participant_id=%s task=%s "
+            "conversation_sent=%s response_id=%s conversation_returned=%s",
+            participant_id,
+            task,
+            conversation_sent,
+            response_id,
+            next_conversation_id,
+        )
+        if not next_conversation_id:
+            logger.warning(
+                "OpenAI response had no conversation id (participant_id=%s task=%s response_id=%s); "
+                "server-side thread may not persist for the next call.",
+                participant_id,
+                task,
+                response_id,
+            )
 
         content = self._extract_text(response)
         return self._parse_json_response(content)

--- a/agent/config.py
+++ b/agent/config.py
@@ -11,8 +11,7 @@ from agent.prompts import (
 
 
 DEFAULT_AGENT_SETTINGS: Dict[str, Any] = {
-    "model_name": "gpt-4.1",
-    "temperature": 0.95,
+    "model_name": "gpt-5.4",
     "system_prompts": {
         "make_offer": system_prompt_make_offer,
         "get_offers": system_prompt_get_offers,
@@ -46,11 +45,8 @@ def get_agent_settings(player: Optional[Any] = None) -> Dict[str, Any]:
         if isinstance(prompt_overrides, dict):
             settings["system_prompts"].update(prompt_overrides)
     model_name = session_cfg.get("agent_model_name")
-    temperature = session_cfg.get("agent_temperature")
     if model_name:
         settings["model_name"] = model_name
-    if temperature is not None:
-        settings["temperature"] = temperature
     return settings
 
 

--- a/agent/prompts.py
+++ b/agent/prompts.py
@@ -69,7 +69,19 @@ def build_system_prompt_choose_effort() -> str:
         "- Remember: Your payoff = 400 + wage - effort_cost, so calculate carefully"
     )
     response_format = "Return only JSON with keys work_effort (1-10) and reasoning (explain your logic)."
-    return _build_system_prompt(base, "ChooseEffort.html", response_format)
+
+    # ChooseEffort.html gates training vs no-training copy with {{ if contract.training }} /
+    # {{ else }}; _extract_template_instructions strips tags but keeps both branches, which
+    # contradict each other. Training facts belong in game_state; omit the duplicate reminders.
+    instructions = [
+        block
+        for block in _extract_template_instructions("ChooseEffort.html")
+        if "As a reminder, your employer" not in block
+    ]
+    if instructions:
+        instruction_text = "Page instructions:\n- " + "\n- ".join(instructions)
+        return f"{base}\n{instruction_text}\n{response_format}"
+    return f"{base}\n{response_format}"
 
 
 def build_system_prompt_make_offer() -> str:

--- a/labor_market/agent_policy.py
+++ b/labor_market/agent_policy.py
@@ -11,6 +11,31 @@ if TYPE_CHECKING:
     from labor_market import Player
 
 
+def _conversation_store(player: "Player") -> dict:
+    store = player.participant.vars.get("agent_conversations", {})
+    if not isinstance(store, dict):
+        store = {}
+    return store
+
+
+def _conversation_key(player: "Player") -> str:
+    return "game"
+
+
+def _get_conversation_id(player: "Player") -> str | None:
+    store = _conversation_store(player)
+    value = store.get(_conversation_key(player))
+    return value if isinstance(value, str) and value else None
+
+
+def _save_conversation_id(player: "Player", conversation_id: str | None) -> None:
+    if not conversation_id:
+        return
+    store = _conversation_store(player)
+    store[_conversation_key(player)] = conversation_id
+    player.participant.vars["agent_conversations"] = store
+
+
 def append_agent_reasoning(player: "Player", page_name: str, decision: dict | None):
     participant = player.participant
     log = participant.vars.get("agent_reasoning_log", [])
@@ -123,13 +148,14 @@ def make_agent_offer(player: "Player", game_state: dict) -> dict:
     offer_training = False
     agent = Agent(
         model_name=settings["model_name"],
-        temperature=settings["temperature"],
         system_prompt=settings["system_prompts"]["make_offer"],
+        conversation_id=_get_conversation_id(player),
     )
     decision = agent.make_offer(
         participant_id=player.id_in_group,
         game_state=game_state,
     )
+    _save_conversation_id(player, agent.conversation_id)
     print(f"Agent decision (MakeOffer) for Manager {player.id_in_group}: {decision}")
     if isinstance(decision, dict):
         print(f"Agent reasoning (MakeOffer) for Manager {player.id_in_group}: {decision.get('reasoning')}")
@@ -169,13 +195,14 @@ def get_agent_offer(player: "Player", game_state: dict) -> dict:
     settings = get_agent_settings(player)
     agent = Agent(
         model_name=settings["model_name"],
-        temperature=settings["temperature"],
         system_prompt=settings["system_prompts"]["get_offers"],
+        conversation_id=_get_conversation_id(player),
     )
     decision = agent.respond_to_offer(
         participant_id=player.id_in_group,
         game_state=game_state,
     )
+    _save_conversation_id(player, agent.conversation_id)
     print(f"Agent decision (GetOffers) for Worker {player.id_in_group}: {decision}")
     if isinstance(decision, dict):
         print(f"Agent reasoning (GetOffers) for Worker {player.id_in_group}: {decision.get('reasoning')}")
@@ -197,13 +224,14 @@ def choose_agent_effort(player: "Player", game_state: dict) -> dict:
     settings = get_agent_settings(player)
     agent = Agent(
         model_name=settings["model_name"],
-        temperature=settings["temperature"],
         system_prompt=settings["system_prompts"]["choose_effort"],
+        conversation_id=_get_conversation_id(player),
     )
     decision = agent.choose_effort(
         participant_id=player.id_in_group,
         game_state=game_state,
     )
+    _save_conversation_id(player, agent.conversation_id)
     print(f"Agent decision (ChooseEffort) for Worker {player.id_in_group}: {decision}")
     if isinstance(decision, dict):
         print(f"Agent reasoning (ChooseEffort) for Worker {player.id_in_group}: {decision.get('reasoning')}")

--- a/labor_market/tests.py
+++ b/labor_market/tests.py
@@ -143,7 +143,6 @@ class PlayerBot(Bot):
                         agent_settings = get_agent_settings(self.player)
                         agent = Agent(
                             model_name=agent_settings["model_name"],
-                            temperature=agent_settings["temperature"],
                             system_prompt=agent_settings["system_prompts"]["make_offer"],
                         )
                         decision = agent.make_offer(
@@ -232,7 +231,6 @@ class PlayerBot(Bot):
                         agent_settings = get_agent_settings(self.player)
                         agent = Agent(
                             model_name=agent_settings["model_name"],
-                            temperature=agent_settings["temperature"],
                             system_prompt=agent_settings["system_prompts"]["get_offers"],
                         )
                         decision = agent.respond_to_offer(
@@ -300,7 +298,6 @@ class PlayerBot(Bot):
                 agent_settings = get_agent_settings(self.player)
                 agent = Agent(
                     model_name=agent_settings["model_name"],
-                    temperature=agent_settings["temperature"],
                     system_prompt=agent_settings["system_prompts"]["choose_effort"],
                 )
                 decision = agent.choose_effort(


### PR DESCRIPTION
- changed the agent API to responses for statefulness
- upgraded agent to openai 5.4
- removed temperature because openai 5+ models do not need temperature settings
- introduced some tracing in logs to verify statefulness (Note that now messages can be seen under the Labor market experiment in Openai platform).
- noticed a bug where the scraping of the choose effort html template to build the prompt for choose effort was causing contradictory statements 

The goal is to study the difference between previous behavior and if statefulness brings any changes.